### PR TITLE
notify that model directory has benn made

### DIFF
--- a/aero_description/scripts/setup_models_directory.sh
+++ b/aero_description/scripts/setup_models_directory.sh
@@ -41,7 +41,9 @@ add_missings() {
 	    dir_exists=$(ls $(rospack find aero_description)/models | grep $dirname)
 	    if [[ $dir_exists == '' ]]
 	    then
+		printf "couldn't find model directory\n"
 		mkdir $(rospack find aero_description)/models/$dirname
+		printf "made directory: $(rospack find aero_description)/models/$dirname\n"
 	    fi
 	    # echo "getting $filename"
 	    cp $get $(rospack find aero_description)/models/$dirname/$filename


### PR DESCRIPTION
'''
find: `/home/leus/ros/indigo/src/aero-ros-pkg-prerelease/aero_description/models/aero_upper_meshes': そのようなファイルやディレクトリはありません
'''
This message scared me, but maybe it's in the specifications.
You should notify that.
