### PR TITLE
Add util servo

### DIFF
--- a/aero_startup/.templates/aero_hardware_interface/AeroControllers.cc
+++ b/aero_startup/.templates/aero_hardware_interface/AeroControllers.cc
@@ -23,6 +23,38 @@ AeroUpperController::~AeroUpperController()
 }
 
 //////////////////////////////////////////////////
+void AeroUpperController::util_servo_on() {
+  boost::mutex::scoped_lock lock(ctrl_mtx_);
+
+  std::vector<uint8_t> dat;
+  dat.resize(8);
+  dat[0] = 0xfd;  // header
+  dat[1] = 0xdf;  // header
+  dat[2] = 0x04;  // data length
+  dat[3] = 0x21;  // servo
+  dat[4] = 0x1d;  // ID29
+  dat[5] = 0x00;  // on
+  dat[6] = 0x01;  // on
+  dat[7] = 0xbc;  // checksum
+  ser_.send_data(dat);
+}
+void AeroUpperController::util_servo_off() {
+  boost::mutex::scoped_lock lock(ctrl_mtx_);
+
+  std::vector<uint8_t> dat;
+  dat.resize(8);
+  dat[0] = 0xfd;  // header
+  dat[1] = 0xdf;  // header
+  dat[2] = 0x04;  // data length
+  dat[3] = 0x21;  // servo
+  dat[4] = 0x1d;  // ID29
+  dat[5] = 0x00;  // off
+  dat[6] = 0x00;  // off
+  dat[7] = 0xbd;  // checksum
+  ser_.send_data(dat);
+}
+
+//////////////////////////////////////////////////
 AeroLowerController::AeroLowerController(const std::string& _port) :
     AeroControllerProto(_port, ID_LOWER)
 {

--- a/aero_startup/aero_hardware_interface/AeroControllerNode.cc
+++ b/aero_startup/aero_hardware_interface/AeroControllerNode.cc
@@ -53,6 +53,14 @@ AeroControllerNode::AeroControllerNode(const ros::NodeHandle& _nh,
           &AeroControllerNode::WheelCommandCallback,
           this);
 
+  ROS_INFO(" create utility servo sub");
+  util_sub_ =
+      nh_.subscribe(
+          "util_servo",
+          10,
+          &AeroControllerNode::UtilServoCallback,
+          this);
+
   bool get_state = true;
   nh_.param<bool> ("get_state", get_state, true);
 
@@ -119,7 +127,7 @@ void AeroControllerNode::JointTrajectoryCallback(
     // note, an illegal name will return from process anyway
     name_duplicate_check[_msg->joint_names[i]] = false; // any value
 
-    // try finding name from upper_ 
+    // try finding name from upper_
     id_in_msg_to_ordered_id[i] =
         upper_.get_ordered_angle_id(_msg->joint_names[i]);
 
@@ -348,5 +356,20 @@ void AeroControllerNode::WheelCommandCallback(
     lower_.flush();
     lower_.set_wheel_velocity(wheel_vector, time_msec);
     // usleep(static_cast<int32_t>(time_sec * 1000.0 * 1000.0));
+  }
+}
+
+void AeroControllerNode::UtilServoCallback(
+    const std_msgs::Int32::ConstPtr& _msg)
+{
+  boost::mutex::scoped_lock lock(mtx_);
+
+  if (_msg->data == 0)
+  {
+    upper_.util_servo_off();
+  }
+  else
+  {
+    upper_.util_servo_on();
   }
 }

--- a/aero_startup/aero_hardware_interface/AeroControllerNode.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllerNode.hh
@@ -22,6 +22,7 @@
 
 #include <tf/transform_broadcaster.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Int32.h>
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/Twist.h>
 
@@ -71,6 +72,11 @@ namespace aero
     private: void WheelCommandCallback(
 	const trajectory_msgs::JointTrajectory::ConstPtr& _msg);
 
+      /// @brief subscribe utility servo message
+      /// @param _msg true: on, false :off
+    private: void UtilServoCallback(
+        const std_msgs::Int32::ConstPtr& _msg);
+
     private: AeroUpperController upper_;
 
     private: AeroLowerController lower_;
@@ -84,6 +90,8 @@ namespace aero
     private: ros::Subscriber wheel_servo_sub_;
 
     private: ros::Subscriber wheel_sub_;
+
+    private: ros::Subscriber util_sub_;
 
     private: ros::Publisher state_pub_;
 

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.hh
@@ -61,7 +61,7 @@ namespace aero
 
       /// @brief send raw data to SEED controller
       /// @param _send_data raw data buffer
-    private: void send_data(std::vector<uint8_t>& _send_data);
+    public: void send_data(std::vector<uint8_t>& _send_data);
 
     private: io_service io_;
 

--- a/aero_startup/aero_hardware_interface/AeroControllers.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllers.hh
@@ -35,6 +35,12 @@ namespace aero
 
       /// @brief destructor
     public: ~AeroUpperController();
+
+    /// @brief utility servo on command
+    public: void util_servo_on();
+
+    /// @brief utility servo off command
+    public: void util_servo_off();
     };
 
   /// @brief Lower body controller


### PR DESCRIPTION
seed controllerに別途デバイスをつなぎ，スイッチを制御できるよう改造していますが，
現状なぜかroseusを経由してトピックを送信するとコントローラのプロセスが固まってしまうようです．
`rostopic pub`だと大丈夫です．

どこか見落としがあるかもしれないので，このあと頭が冴えている時に
とくに`send_data`を直接叩いているのはかなり想定外な使い方なので，
そこを見なおしたり，roseusが大元の原因になっているはずなので
pythonで一段かませたらどうなるかを見てみます．

若干気になっているのは，
一度コントローラが固まると再起動してもUSBの通信が詰まってしまって電源再投入が必要．
これはひょっとしたらコントローラ側でロックを正常にかけられていない可能性もあります．
