### PR TITLE
reset-poseなどでハンドを更新しない

### DIFF
--- a/aeroeus/aero-interface.l
+++ b/aeroeus/aero-interface.l
@@ -59,6 +59,11 @@
       (send self hand :f-2p :joint-angle (elt hand-vector 2))
       (send self hand :f-3p :joint-angle (elt hand-vector 3))
       hand-vector))
+
+
+    (:reset-manip-pose () (send self :angle-vector (float-vector 0.000000 -15.000000 0.000000 -90.000000 0.000000 0.000000 0.000000 (send self :rarm :t-1p :joint-angle) (send self :rarm :f-1p :joint-angle) (send self :rarm :f-2p :joint-angle) (send self :rarm :f-3p :joint-angle) 0.000000 15.000000 0.000000 -90.000000 0.000000 0.000000 0.000000 (send self :larm :t-1p :joint-angle) (send self :larm :f-1p :joint-angle) (send self :larm :f-2p :joint-angle) (send self :larm :f-3p :joint-angle) 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000)))
+    (:reset-pose () (send self :angle-vector (float-vector 0.000000 0.000000 0.000000 -90.000000 0.000000 0.000000 0.000000 (send self :rarm :t-1p :joint-angle) (send self :rarm :f-1p :joint-angle) (send self :rarm :f-2p :joint-angle) (send self :rarm :f-3p :joint-angle) 0.000000 0.000000 0.000000 -90.000000 0.000000 0.000000 0.000000 (send self :larm :t-1p :joint-angle) (send self :larm :f-1p :joint-angle) (send self :larm :f-2p :joint-angle) (send self :larm :f-3p :joint-angle) 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000)))
+    (:reset-terrain-pose () (send self :angle-vector (float-vector 0.000000 -15.000000 0.000000 -90.000000 0.000000 0.000000 0.000000 (send self :rarm :t-1p :joint-angle) (send self :rarm :f-1p :joint-angle) (send self :rarm :f-2p :joint-angle) (send self :rarm :f-3p :joint-angle) 0.000000 15.000000 0.000000 -90.000000 0.000000 0.000000 0.000000 (send self :larm :t-1p :joint-angle) (send self :larm :f-1p :joint-angle) (send self :larm :f-2p :joint-angle) (send self :larm :f-3p :joint-angle) 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000)))
   )
 
 


### PR DESCRIPTION
ロボットモデルでreset-pose,reset-manip-pose,terrain-poseを行うとハンドの角度が0で更新されますが，graspは別管理なので，モデルのハンドの角度が変わらないようにしました．

aero-interface.lに書いているのは，元々これらのメソッドが宣言されているaero_upper.lがaero_four_legs/model/genなど複数箇所にあるのと，それらが編集しないように注意書きがあるからです．

以下画像はハンドの角度をモデル上で変えた後それぞれのメソッドを呼び出した時の様子です．
![screenshot from 2016-07-21 16 39 00](https://cloud.githubusercontent.com/assets/9003596/17015227/f3a35b0e-4f63-11e6-9e08-4bda2f604c80.png)
