### PR TITLE
include dir doesnt altready exist

### DIFF
--- a/aero_moveit_config/CMakeLists.txt
+++ b/aero_moveit_config/CMakeLists.txt
@@ -4,7 +4,6 @@ project(aero_moveit_config)
 find_package(catkin REQUIRED)
 
 catkin_package(
-  INCLUDE_DIRS include
 )
 
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
aero_moveit_configには既にincludeディレクトリは存在しないのに、CmakeListsに残っていてコンパイルできなくなっていたので消去しました。