### PR TITLE
movegroup launcher with argument swtiching executing rviz or not

### DIFF
--- a/aero_moveit_config/launch/moveit_plannning_execution.launch
+++ b/aero_moveit_config/launch/moveit_plannning_execution.launch
@@ -1,11 +1,13 @@
 <launch>
+ <arg name="display" default="false"/>
+
  <node pkg="tf" type="static_transform_publisher" name="virtual_odom_base_tf_publisher" args="0 0 0 0 0 0 odom_combined virtual_lifter_x_link  100" />
 
  <include file="$(find aero_moveit_config)/launch/move_group.launch">
   <arg name="publish_monitored_planning_scene" value="true" />
  </include>
 
- <include file="$(find aero_moveit_config)/launch/moveit_rviz.launch"> 
+ <include file="$(find aero_moveit_config)/launch/moveit_rviz.launch" if="$(arg display)"> 
     <arg name="config" value="true"/>
  </include>
 


### PR DESCRIPTION
別でrvizを立ちあげたい時やrvizが必要無い時用にrviz無しでmove_groupを立ち上げるオプションです
``` bash
roslaunch aero_moveit_config moveit_planning_execution # without rviz
roslaunch aero_moveit_config moveit_planning_execution display:=true # with rviz
```