### PR TITLE
update aero_hardware_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ T.B.D.
 roslaunch aero_startup aero_bringup.launch
 ```
 
+### View Robot Model
+
+```
+rosrun rviz rviz
+```
+
+then add RobotModel, change Robot Description to `aero_description`.
+
+
 ### Run euslisp
 
 ```

--- a/aero_description/typeF/headers/Constants.hh
+++ b/aero_description/typeF/headers/Constants.hh
@@ -5,10 +5,6 @@ namespace aero
 {
   namespace controller
   {
-    // header offset = 5bytes
-    const static size_t RAW_HEADER_OFFSET = 5;
-    // data length = 68bytes
-    const static size_t RAW_DATA_LENGTH = 68;
     // id: upper = 1, lower = 2
     const static uint8_t ID_UPPER = 1;
     const static uint8_t ID_LOWER = 2;
@@ -136,16 +132,6 @@ namespace aero
 
     // LOWER :
 
-    // command list
-    const static uint8_t CMD_MOTOR_CUR = 0x01;
-    const static uint8_t CMD_MOTOR_ACC = 0x03;
-    const static uint8_t CMD_MOTOR_GAIN = 0x04;
-    const static uint8_t CMD_GET_POS = 0x41;
-    const static uint8_t CMD_GET_CUR = 0x42;
-    const static uint8_t CMD_GET_TMP = 0x43;
-    const static uint8_t CMD_MOTOR_SRV = 0x21; // servo
-    const static uint8_t CMD_MOVE_ABS = 0x14;
-    const static uint8_t CMD_MOVE_SPD = 0x15; // wheels
   }
 }
 

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.cc
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.cc
@@ -107,8 +107,10 @@ void SEED485Controller::send_command(
   // check sum
   int32_t b_check_sum = 0;
 
-  for (size_t i = 2; i < data.size() - 1; ++i)
+  for (size_t i = 2; i < data.size() - 1; ++i) {
     b_check_sum += data[i];
+  }
+
   data[data.size() - 1] =
     ~(reinterpret_cast<uint8_t*>(&b_check_sum)[0]);
 
@@ -132,8 +134,10 @@ void SEED485Controller::send_command(
   // check sum
   int32_t b_check_sum = 0;
 
-  for (size_t i = 2; i < RAW_DATA_LENGTH - 1; ++i)
+  for (size_t i = 2; i < RAW_DATA_LENGTH - 1; ++i) {
     b_check_sum += _send_data[i];
+  }
+
   _send_data[RAW_DATA_LENGTH - 1] =
     ~(reinterpret_cast<uint8_t*>(&b_check_sum)[0]);
 
@@ -254,8 +258,9 @@ int AeroControllerProto::get_number_of_angle_joints()
 int32_t AeroControllerProto::get_ordered_angle_id(std::string _name)
 {
   auto it = angle_joint_indices_.find(_name);
-  if (it != angle_joint_indices_.end())
-      return angle_joint_indices_[_name];
+  if (it != angle_joint_indices_.end()) {
+    return angle_joint_indices_[_name];
+  }
   return -1;
 }
 
@@ -342,10 +347,11 @@ void AeroControllerProto::get_data(std::vector<int16_t>& _stroke_vector)
         decode_short_(&dat[RAW_HEADER_OFFSET + aji.raw_index * 2]);
 
       // check value
-      if (_stroke_vector[aji.stroke_index] > 0x7fff)
+      if (_stroke_vector[aji.stroke_index] > 0x7fff) {
         _stroke_vector[aji.stroke_index] -= std::pow(2, 16);
-      else if (_stroke_vector[aji.stroke_index] == 0x7fff)
+      } else if (_stroke_vector[aji.stroke_index] == 0x7fff) {
         _stroke_vector[aji.stroke_index] = 0;
+      }
     }
   }
 
@@ -353,10 +359,11 @@ void AeroControllerProto::get_data(std::vector<int16_t>& _stroke_vector)
   if (cmd == 0x52) {
     uint8_t status0 = dat[RAW_HEADER_OFFSET + 60];
     uint8_t status1 = dat[RAW_HEADER_OFFSET + 61];
-    if ((status0 >> 5) == 1 || (status1 >> 5) == 1)
+    if ((status0 >> 5) == 1 || (status1 >> 5) == 1) {
       bad_status_ = true;
-    else
+    } else {
       bad_status_ = false;
+    }
   }
 
 }
@@ -387,9 +394,11 @@ void AeroControllerProto::set_position(
   boost::mutex::scoped_lock lock(ctrl_mtx_);
 
   // for ROS
-  for (size_t i = 0; i < _stroke_vector.size(); ++i)
-    if (_stroke_vector[i] != 0x7fff)
+  for (size_t i = 0; i < _stroke_vector.size(); ++i) {
+    if (_stroke_vector[i] != 0x7fff) {
       stroke_ref_vector_[i] = _stroke_vector[i];
+    }
+  }
 
   // for seed
   std::vector<uint8_t> dat(RAW_DATA_LENGTH);

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.hh
@@ -15,6 +15,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
 
+#include "aero_hardware_interface/CommandList.hh"
 #include "aero_hardware_interface/Constants.hh"
 #include "aero_hardware_interface/AJointIndex.hh"
 
@@ -24,188 +25,190 @@ namespace aero
 {
   namespace controller
   {
-
-  /// @brief SEED controller via USB/RS485
+    /// @brief SEED controller via USB/RS485
     class SEED485Controller
     {
       /// @brief constructor
       /// @param _port USB port file name
       /// @param _id CAN bus ID
-    public: SEED485Controller(const std::string& _port, uint8_t _id);
+     public: SEED485Controller(const std::string& _port, uint8_t _id);
 
       /// @brief destructor
-    public: ~SEED485Controller();
+     public: ~SEED485Controller();
 
       /// @brief read from SEED controller
-    public: void read(std::vector<uint8_t>& _read_data);
+     public: void read(std::vector<uint8_t>& _read_data);
 
       /// @brief send command to SEED controller
       /// @param _cmd Command ID
       /// @param _time Destination time
       /// @param _send_data data buffer
-    public: void send_command(uint8_t _cmd, uint16_t _time,
-			      std::vector<uint8_t>& _send_data);
+     public: void send_command(uint8_t _cmd, uint16_t _time,
+                               std::vector<uint8_t>& _send_data);
 
       /// @brief send single command to SEED controller
       /// @param _cmd Command ID
       /// @param _num Send ID
       /// @param _data data
-    public: void send_command(uint8_t _cmd, uint8_t _num, uint16_t _data);
+     public: void send_command(uint8_t _cmd, uint8_t _num, uint16_t _data);
 
-    public: void send_command(uint8_t _cmd, uint8_t _sub, uint16_t _time,
-			      std::vector<uint8_t>& _send_data);
+     public: void send_command(uint8_t _cmd, uint8_t _sub, uint16_t _time,
+                               std::vector<uint8_t>& _send_data);
 
       /// @brief send_executing script command
-    public: void AERO_Snd_Script(uint16_t sendnum, uint8_t scriptnum);
+     public: void AERO_Snd_Script(uint16_t sendnum, uint8_t scriptnum);
 
-    /// @brief flush io buffer
-    public: void flush();
+      /// @brief flush io buffer
+     public: void flush();
 
       /// @brief send raw data to SEED controller
       /// @param _send_data raw data buffer
-    public: void send_data(std::vector<uint8_t>& _send_data);
+     public: void send_data(std::vector<uint8_t>& _send_data);
 
-    private: io_service io_;
+     private: io_service io_;
 
-    private: serial_port ser_;
+     private: serial_port ser_;
 
-    private: uint8_t id_;
+     private: uint8_t id_;
 
-    private: bool verbose_;
+     private: bool verbose_;
 
-    private: boost::mutex mtx_;
-    };
+     private: boost::mutex mtx_;
+    };  // SEED485Controller
 
-    /// @brief decode short(int16_t) from byte(uint8_t)
-    int16_t decode_short_(uint8_t* _raw);
-
-    /// @brief ecnode short(int16_t) to byte(uint8_t)
-    void encode_short_(int16_t _value, uint8_t* _raw);
-
-  /// @brief super class of body controller,
-  /// has SEED485Controller and some SEED command fucntions.
+    /// @brief super class of body controller,
+    /// has SEED485Controller and some SEED command fucntions.
     class AeroControllerProto
     {
       /// @brief constructor
       /// @param _port USB port file name
       /// @param _id CAN bus ID
-    public: AeroControllerProto(const std::string& _port, uint8_t _id);
+     public: AeroControllerProto(const std::string& _port, uint8_t _id);
 
       /// @brief destructor
-    public: ~AeroControllerProto();
+     public: ~AeroControllerProto();
 
-    /// @brief servo on command
-    public: void servo_on();
+      /// @brief servo on command
+     public: void servo_on();
 
-    /// @brief servo off command
-    public: void servo_off();
+      /// @brief servo off command
+     public: void servo_off();
 
-    /// @brief servo toggle command
-    /// @param _d0 1: on, 0: off
-    protected: void servo_command(int16_t _d0);
+      /// @brief servo toggle command
+      /// @param _d0 1: on, 0: off
+     protected: void servo_command(int16_t _d0);
 
-    public: std::vector<int16_t> get_reference_stroke_vector();
+     public: std::vector<int16_t> get_reference_stroke_vector();
 
-    public: std::vector<int16_t> get_actual_stroke_vector();
+     public: std::vector<int16_t> get_actual_stroke_vector();
 
-    public: std::vector<int16_t> get_status_vec();
+     public: std::vector<int16_t> get_status_vec();
 
-    public: std::string get_stroke_joint_name(size_t _idx);
+     public: std::string get_stroke_joint_name(size_t _idx);
 
-    public: int get_number_of_angle_joints();
+     public: int get_number_of_angle_joints();
 
-    public: int32_t get_ordered_angle_id(std::string _name);
+     public: int32_t get_ordered_angle_id(std::string _name);
 
-    public: bool get_status();
+     public: bool get_status();
 
-    public: bool get_status(std::vector<bool>& _status_vector);
+     public: bool get_status(std::vector<bool>& _status_vector);
 
-    /// @brief get current position from seed_
-    ///   to access position externally, use get_actual_stroke_vector
-    public: void update_position();
+      /// @brief get current position from seed_
+      ///   to access position externally, use get_actual_stroke_vector
+     public: void update_position();
 
-    /// @brief updates robot status (checks step out joints)
-    public: void update_status();
+      /// @brief updates robot status (checks step out joints)
+     public: void update_status();
 
-    public: void reset_status();
+     public: void reset_status();
 
-    /// @brief send Get_Cur command
-    /// @param _stroke_vector stroke vector
-    public: void get_current(std::vector<int16_t>& _stroke_vector);
+      /// @brief send Get_Cur command
+      /// @param _stroke_vector stroke vector
+     public: void get_current(std::vector<int16_t>& _stroke_vector);
 
-    /// @brief send Get_Tmp command
-    /// @param _stroke_vector stroke vector
-    public: void get_temperature(std::vector<int16_t>& _stroke_vector);
+      /// @brief send Get_Tmp command
+      /// @param _stroke_vector stroke vector
+     public: void get_temperature(std::vector<int16_t>& _stroke_vector);
 
-    /// @brief get data from buffer,
-    ///   this does not call command, but only read from buffer
-    /// @param _stroke_vector stroke vector
-    protected: void get_data(std::vector<int16_t>& _stroke_vector);
+      /// @brief get data from buffer,
+      ///   this does not call command, but only read from buffer
+      /// @param _stroke_vector stroke vector
+     protected: void get_data(std::vector<int16_t>& _stroke_vector);
 
-    /// @brief abstract of get commands
-    /// @param _cmd command id
-    /// @param _stroke_vector stroke vector
-    protected: void get_command(uint8_t _cmd,
-				std::vector<int16_t>& _stroke_vector);
+      /// @brief abstract of get commands
+      /// @param _cmd command id
+      /// @param _stroke_vector stroke vector
+     protected: void get_command(uint8_t _cmd,
+                                 std::vector<int16_t>& _stroke_vector);
 
-    protected: void get_command(uint8_t _cmd, uint8_t _sub,
-				std::vector<int16_t>& _stroke_vector);
+     protected: void get_command(uint8_t _cmd, uint8_t _sub,
+                                 std::vector<int16_t>& _stroke_vector);
 
-    /// @brief set position command
-    /// @param _stroke_vector stroke vector, MUST be DOF bytes
-    /// @param _time time[ms]
-    public: void set_position(std::vector<int16_t>& _stroke_vector,
-			      uint16_t _time);
+      /// @brief set position command
+      /// @param _stroke_vector stroke vector, MUST be DOF bytes
+      /// @param _time time[ms]
+     public: void set_position(std::vector<int16_t>& _stroke_vector,
+                               uint16_t _time);
 
-    /// @brief send Motor_Cur command
-    /// @param _stroke_vector stroke vector
-    public: void set_max_current(std::vector<int16_t>& _stroke_vector);
+      /// @brief send Motor_Cur command
+      /// @param _stroke_vector stroke vector
+     public: void set_max_current(std::vector<int16_t>& _stroke_vector);
 
-    /// @brief send Motor_Cur command
-    /// @param _num Send id
-    /// @param _dat data
-    public: void set_max_single_current(int8_t _num, int16_t _dat);
+      /// @brief send Motor_Cur command
+      /// @param _num Send id
+      /// @param _dat data
+     public: void set_max_single_current(int8_t _num, int16_t _dat);
 
-    /// @brief send Motor_Acc command
-    /// @param _stroke_vector stroke vector
-    public: void set_accel_rate(std::vector<int16_t>& _stroke_vector);
+      /// @brief send Motor_Acc command
+      /// @param _stroke_vector stroke vector
+     public: void set_accel_rate(std::vector<int16_t>& _stroke_vector);
 
-    /// @brief send Motor_Gain command
-    /// @param _stroke_vector stroke vector
-    public: void set_motor_gain(std::vector<int16_t>& _stroke_vector);
+      /// @brief send Motor_Gain command
+      /// @param _stroke_vector stroke vector
+     public: void set_motor_gain(std::vector<int16_t>& _stroke_vector);
 
-    /// @brief abstract of set commands
-    /// @param _cmd command id
-    /// @param _stroke_vector stroke vector
-    protected: void set_command(uint8_t _cmd,
-				std::vector<int16_t>& _stroke_vector);
+      /// @brief abstract of set commands
+      /// @param _cmd command id
+      /// @param _stroke_vector stroke vector
+     protected: void set_command(uint8_t _cmd,
+                                 std::vector<int16_t>& _stroke_vector);
 
-    /// @brief stoke_vector to raw command bytes
-    protected: void stroke_to_raw_(std::vector<int16_t>& _stroke,
-				   std::vector<uint8_t>& _raw);
+      /// @brief stoke_vector to raw command bytes
+     protected: void stroke_to_raw_(std::vector<int16_t>& _stroke,
+                                    std::vector<uint8_t>& _raw);
 
-    protected: bool verbose_;
+     protected: bool verbose_;
 
-    protected: boost::mutex ctrl_mtx_;
+     protected: boost::mutex ctrl_mtx_;
 
-    protected: SEED485Controller seed_;
+     protected: SEED485Controller seed_;
 
-    protected: std::vector<int16_t> stroke_vector_;
+     protected: std::vector<int16_t> stroke_vector_;
 
-    protected: std::vector<int16_t> stroke_ref_vector_;
+     protected: std::vector<int16_t> stroke_ref_vector_;
 
-    protected: std::vector<int16_t> stroke_cur_vector_;
+     protected: std::vector<int16_t> stroke_cur_vector_;
 
-    protected: std::vector<AJointIndex> stroke_joint_indices_;
+     protected: std::vector<AJointIndex> stroke_joint_indices_;
 
-    protected: std::vector<int16_t> status_vector_;
+     protected: std::vector<int16_t> status_vector_;
 
-    protected: bool bad_status_;
+     protected: bool bad_status_;
 
-    protected:
+     protected:
       std::unordered_map<std::string, int32_t> angle_joint_indices_;
-    };
+    };  // AeroControllerProto
 
+  /////////////////////
+  // nonclass functions
+  /////////////////////
+
+  /// @brief decode short(int16_t) from byte(uint8_t)
+  int16_t decode_short_(uint8_t* _raw);
+
+  /// @brief ecnode short(int16_t) to byte(uint8_t)
+  void encode_short_(int16_t _value, uint8_t* _raw);
   }
 }
 

--- a/aero_startup/aero_hardware_interface/CommandList.hh
+++ b/aero_startup/aero_hardware_interface/CommandList.hh
@@ -1,0 +1,26 @@
+#ifndef AERO_CONTROLLER_COMMAND_LIST_H_
+#define AERO_CONTROLLER_COMMAND_LIST_H_
+
+namespace aero
+{
+  namespace controller
+  {
+    // header offset = 5bytes
+    const static size_t RAW_HEADER_OFFSET = 5;
+    // data length = 68bytes
+    const static size_t RAW_DATA_LENGTH = 68;
+
+    // command list
+    const static uint8_t CMD_MOTOR_CUR = 0x01;
+    const static uint8_t CMD_MOTOR_ACC = 0x03;
+    const static uint8_t CMD_MOTOR_GAIN = 0x04;
+    const static uint8_t CMD_GET_POS = 0x41;
+    const static uint8_t CMD_GET_CUR = 0x42;
+    const static uint8_t CMD_GET_TMP = 0x43;
+    const static uint8_t CMD_MOTOR_SRV = 0x21; // servo
+    const static uint8_t CMD_MOVE_ABS = 0x14;
+    const static uint8_t CMD_MOVE_SPD = 0x15; // wheels
+  }
+}
+
+#endif  // AERO_CONTROLLER_COMMAND_LIST_H_


### PR DESCRIPTION
大きくは変更していませんが，
AeroControllerProtoのインデントが壊れて全く読めなくなっていたのを修正したため，
かなりのdiffが出てしまっています．

- README.mdにrvizの見方を追加．
- {robotdir}/headers/Constants.hhから，明らかに共通となるコマンドの定数を抜いてCommandList.hhを作る．
- スコープがわかりにくいところにブレースを追加．