### PR TITLE
add tf broadcast

### DIFF
--- a/aero_std/CMakeLists.txt
+++ b/aero_std/CMakeLists.txt
@@ -82,6 +82,9 @@ add_executable(spot_manager src/spot_manager.cc)
 target_link_libraries(spot_manager ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} spot_list)
 add_dependencies(spot_manager ${PROJECT_NAME}_gencpp)
 
+catkin_add_gtest(test_spot test/test_spot.cc)
+target_link_libraries(test_spot ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} spot_list)
+
 add_executable(look_at src/look_at.cc)
 target_link_libraries(look_at ${catkin_LIBRARIES} aero_moveit_interface)
 

--- a/aero_std/include/aero_std/spot_list.hh
+++ b/aero_std/include/aero_std/spot_list.hh
@@ -16,6 +16,10 @@ struct Spot {
   geometry_msgs::Pose pose;
 };
 
+Spot MakeSpot(std::string name,
+              float tx, float ty, float tz,
+              float qx, float qy, float qz, float qw);
+
 class SpotList {
 public:
   SpotList();

--- a/aero_std/src/spot_list.cc
+++ b/aero_std/src/spot_list.cc
@@ -4,6 +4,31 @@
 
 namespace aero {
 
+/// @brief make Spot from args
+/// @param name spot name
+/// @param tx position x
+/// @param ty position y
+/// @param tz position z
+/// @param qx quaternion x
+/// @param qy quaternion y
+/// @param qz quaternion z
+/// @param qw quaternion w
+Spot MakeSpot(std::string name,
+              float tx, float ty, float tz,
+              float qx, float qy, float qz, float qw) {
+  Spot spot;
+  spot.name = name;
+  spot.pose.position.x = tx;
+  spot.pose.position.y = ty;
+  spot.pose.position.z = tz;
+  spot.pose.orientation.x = qx;
+  spot.pose.orientation.y = qy;
+  spot.pose.orientation.z = qz;
+  spot.pose.orientation.w = qw;
+
+  return spot;
+}
+
 SpotList::SpotList() {
 }
 

--- a/aero_std/src/spot_manager.cc
+++ b/aero_std/src/spot_manager.cc
@@ -1,12 +1,9 @@
 /// @author Shintaro Hori
 
 #include <ros/ros.h>
-#include <fstream>
 
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
-
-#include <yaml-cpp/yaml.h>
 
 #include <aero_std/spot_list.hh>
 

--- a/aero_std/test/test_spot.cc
+++ b/aero_std/test/test_spot.cc
@@ -1,0 +1,98 @@
+/// @author Hiroaki Yaguchi JSK
+
+#include <aero_std/spot_list.hh>
+#include <gtest/gtest.h>
+#include <math.h>
+
+class SpotTest : public::testing::Test {
+protected:
+  virtual void SetUp() {
+    aero::Spot spot;
+
+    spot = aero::MakeSpot(std::string("spot0"),
+                          0, 0, 0,
+                          0, 0, 0, 1);
+    spots_.push_back(spot);
+    spot_list_.SaveSpot(spot);
+
+    spot = aero::MakeSpot(std::string("spot1"),
+                          1, 0, 0,
+                          0, 0, sqrt(0.5), sqrt(0.5));
+    spots_.push_back(spot);
+    spot_list_.SaveSpot(spot);
+
+    spot = aero::MakeSpot(std::string("spot2"),
+                          0, 1, 0,
+                          0, 0, sqrt(0.5), -sqrt(0.5));
+    spots_.push_back(spot);
+    spot_list_.SaveSpot(spot);
+  }
+
+  aero::SpotList spot_list_;
+  std::vector<aero::Spot> spots_;
+};
+
+TEST_F(SpotTest, WriteRead) {
+  ASSERT_EQ(spots_.size(), spot_list_.spots().size());
+
+  std::string filename("/tmp/test.yaml");
+  // write
+  spot_list_.WriteIntoFile(filename);
+  // read
+  spot_list_.ReadFromFile(filename);
+
+  ASSERT_EQ(spots_.size(), spot_list_.spots().size());
+
+  // check all elements
+  for (size_t i = 0; i < spots_.size(); i++) {
+    aero::Spot& spot_a = spots_[i];
+    aero::Spot& spot_b = spot_list_.spots()[i];
+    EXPECT_EQ(spot_a.name, spot_b.name);
+    EXPECT_FLOAT_EQ(spot_a.pose.position.x, spot_b.pose.position.x);
+    EXPECT_FLOAT_EQ(spot_a.pose.position.y, spot_b.pose.position.y);
+    EXPECT_FLOAT_EQ(spot_a.pose.position.z, spot_b.pose.position.z);
+    EXPECT_FLOAT_EQ(spot_a.pose.orientation.x, spot_b.pose.orientation.x);
+    EXPECT_FLOAT_EQ(spot_a.pose.orientation.y, spot_b.pose.orientation.y);
+    EXPECT_FLOAT_EQ(spot_a.pose.orientation.z, spot_b.pose.orientation.z);
+    EXPECT_FLOAT_EQ(spot_a.pose.orientation.w, spot_b.pose.orientation.w);
+  }
+}
+
+TEST_F(SpotTest, SaveDelete) {
+  ASSERT_EQ(spots_.size(), spot_list_.spots().size());
+
+  // overwrite
+  std::string nname("spot0");
+  float nx = 1.0;
+  float ny = 1.0;
+
+  aero::Spot spot = aero::MakeSpot(nname,
+                                   nx, ny, 0,
+                                   0, 0, 0, 1);
+  spot_list_.SaveSpot(spot);
+
+  ASSERT_EQ(spots_.size(), spot_list_.spots().size());
+
+  aero::Spot& spot_a = spot_list_.spots()[spot_list_.GetIndex(nname)];
+  EXPECT_FLOAT_EQ(spot_a.pose.position.x, nx);
+  EXPECT_FLOAT_EQ(spot_a.pose.position.y, ny);
+
+  // add
+  std::string aname("spotx");
+  aero::Spot aspot = aero::MakeSpot(aname,
+                                    0, 0, 0,
+                                    0, 0, 0, 1);
+  spot_list_.SaveSpot(aspot);
+  ASSERT_EQ(spots_.size() + 1, spot_list_.spots().size());
+
+  // delete
+  spot_list_.DeleteSpot(aname);
+  ASSERT_EQ(spots_.size(), spot_list_.spots().size());
+  ASSERT_EQ(spot_list_.GetIndex(aname), -1);
+}
+
+/////////////////////////
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
#234 
機能としては実現できましたが，
DBファイルの管理コードの健全性が非常に怪しく，
テストを追加してからマージしたいと思います．

ところで，現行のコードだと
都度ファイルを開きなおしているのはどういう意図でしょうか？
複数のspotmanagerがいるつもり？
にしては排他制御が入っていないので，そのつもりだと破綻しています．

もし複数のプロセスが同時にアクセスする可能性があるのなら，
sqliteあたりを使ったほうがいいです．
(mongoDBは排他制御ができていないのでNG)
