### PR TITLE
fix goPos bug

### DIFF
--- a/aero_std/src/AeroMoveitInterface.cc
+++ b/aero_std/src/AeroMoveitInterface.cc
@@ -1828,7 +1828,7 @@ geometry_msgs::Pose aero::interface::AeroMoveitInterface::getLocationPose(std::s
 bool aero::interface::AeroMoveitInterface::goPos(double _x,double _y, double _rad, int _timeout_ms)
 {
   // if turn only, move without path planning
-  if (_x == 0.0 && _y == 0.0) return goPosTurnOnly_(_rad, _timeout_ms);
+  // if (_x == 0.0 && _y == 0.0) return goPosTurnOnly_(_rad, _timeout_ms);
 
   goPosAsync(_x, _y, _rad);
 


### PR DESCRIPTION
goPosTrunOnly is not necessary now and it contains bug, so use goPosAsync for
turn only gopos.