### PR TITLE
[AeroControllerProto] fix serial port reading

### DIFF
--- a/aero_startup/aero_hardware_interface/AeroControllerProto.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.hh
@@ -160,10 +160,16 @@ namespace aero
      protected: void get_command(uint8_t _cmd, uint8_t _sub,
                                  std::vector<int16_t>& _stroke_vector);
 
-      /// @brief set position command
+      /// @brief set position command (waiting return of current position)
       /// @param _stroke_vector stroke vector, MUST be DOF bytes
       /// @param _time time[ms]
      public: void set_position(std::vector<int16_t>& _stroke_vector,
+                               uint16_t _time);
+
+      /// @brief set position command (no wait)
+      /// @param _stroke_vector stroke vector, MUST be DOF bytes
+      /// @param _time time[ms]
+     public: void set_position_no_wait(std::vector<int16_t>& _stroke_vector,
                                uint16_t _time);
 
       /// @brief send Motor_Cur command

--- a/aero_startup/aero_hardware_interface/CommandList.hh
+++ b/aero_startup/aero_hardware_interface/CommandList.hh
@@ -11,19 +11,26 @@ namespace aero
     const static size_t RAW_DATA_LENGTH = 68;
 
     // command list
-    const static uint8_t CMD_MOTOR_CUR = 0x01;
-    const static uint8_t CMD_MOTOR_ACC = 0x03;
-    const static uint8_t CMD_MOTOR_GAIN = 0x04;
+    const static uint8_t CMD_MOTOR_CUR  = 0x01; // CMAX
+    const static uint8_t CMD_MOTOR_SPD  = 0x02; // SMAX
+    const static uint8_t CMD_MOTOR_ACC  = 0x03; // ACCEL
+    const static uint8_t CMD_MOTOR_GAIN = 0x04; // GAIN
+    const static uint8_t CMD_MOTOR_PLS  = 0x05; // RATE
+    const static uint8_t CMD_MOTOR_RET  = 0x06; // RETURN
 
-    const static uint8_t CMD_MOVE_ABS = 0x14;
-    const static uint8_t CMD_MOVE_SPD = 0x15; // wheels
+    const static uint8_t CMD_MOVE_ABS_POS = 0x11; // TMOVE
+    const static uint8_t CMD_MOVE_CUR_POS = 0x12; // CMOVE
+    const static uint8_t CMD_MOVE_SPD_POS = 0x13; // SMOVE
+    const static uint8_t CMD_MOVE_ABS_POS_RET = 0x14; // MOVE
+    const static uint8_t CMD_MOVE_SPD = 0x15; // TURN //for wheels
+    const static uint8_t CMD_MOVE_INC_POS_RET = 0x16; // INC
 
     const static uint8_t CMD_MOTOR_SRV = 0x21; // servo
 
     const static uint8_t CMD_GET_POS = 0x41;
     const static uint8_t CMD_GET_CUR = 0x42;
     const static uint8_t CMD_GET_TMP = 0x43;
-    const static uint8_t CMD_GET_AD = 0x44;
+    const static uint8_t CMD_GET_AD  = 0x44;
     const static uint8_t CMD_GET_DIO = 0x45;
 
     const static uint8_t CMD_WATCH_MISSTEP = 0x52;


### PR DESCRIPTION
#82 がこれで解決するはずです。
boostのシリアルポートをreadする場合に、期待した長さが読まれていないことがあり、
それをwaitするようにしました。
返ってくるデータの長さが短くなったり、通信エラーの場合は、無限ループになるかと思います。
（これは、現状でも可能性はある。必要ならば、boostのread_some_asyncなどを使ってタイムアウトできるようにする）
これに伴い、get_command等にあったsleepを除きました。
update_position, set_positionとも最速で戻ってきます。10ms程度です。
#276 の問題は、これでは解決していません。