### PR TITLE
[readme] add description of .bashrc to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ catkin build
 source ~/ros/indigo/devel/setup.bash
 ```
 
+### source setup.bash in ~/.bashrc
+
+Please add the following line to ~/.bashrc
+```
+source ~/ros/indigo/devel/setup.bash
+```
+
 ## Install
 
 ### Clone repository


### PR DESCRIPTION
There is no description of ``.bashrc`` before ``soure ~/.bashrc`` in ``README.md``.

How about adding these lines? Does this make sense?
