### PR TITLE
fix GRASP()

### DIFF
--- a/aero_shop/trx_s/controller/AeroHandController.hh
+++ b/aero_shop/trx_s/controller/AeroHandController.hh
@@ -26,9 +26,9 @@ const std::string r_grasp_fast_check_joint = "r_thumb_joint";
   }
 
 #define L_GRASP() {                                             \
-    map["l_thumb_joint"]      =  larm_angle * M_PI / 180/ 4.0;  \
+    map["l_thumb_joint"]      =  larm_angle * M_PI / 180.0;  \
   }
 #define R_GRASP() {                                             \
-    map["r_thumb_joint"]      =  rarm_angle * M_PI / 180 / 4.0; \
+    map["r_thumb_joint"]      =  rarm_angle * M_PI / 180.0; \
   }
 /// end dependant


### PR DESCRIPTION
```/ 4.0``` is a specific gain for the seed_hand and should not exist for trx_s. see [original controller code](https://github.com/seed-solutions/aero-ros-pkg/blob/5ab02e010771d550d2ae90720ab2dbc05208f328/aero_shop/trx_s/controller/AeroHandController.cc)

probably this was mistakenly copied from seed_hand.