### PR TITLE
adding mesh reference for shop setup

### DIFF
--- a/aero_description/scripts/create_urdf.sh
+++ b/aero_description/scripts/create_urdf.sh
@@ -87,8 +87,26 @@ do
     # check if parts has meshes directory
     if [ -e ${parts_path}/meshes ]
     then
-        mkdir ${aero_description_path}/meshes/${parts_dir}
-        cp -r ${parts_path}/meshes/* ${aero_description_path}/meshes/${parts_dir}
+        if [ -e ${parts_path}/meshes/meshes.txt ]
+        then
+            # handle referenced mesh directory
+            while read meshdir
+            do
+                meshshop_dir=$(echo $meshdir | cut -d/ -f1)
+                meshparts_dir=$(echo $meshdir | cut -d/ -f2)
+                if [[ $meshshop_dir == "aero_shop" ]]
+                then
+                    meshparts_path="$(rospack find aero_description)/../aero_shop/${meshparts_dir}"
+                else
+                    meshparts_path=$(rospack find ${meshshop_dir})/${meshparts_dir}
+                fi
+                mkdir ${aero_description_path}/meshes/${meshparts_dir}
+                cp -r ${meshparts_path}/meshes/* ${aero_description_path}/meshes/${meshparts_dir}
+            done < ${parts_path}/meshes/meshes.txt
+        else
+            mkdir ${aero_description_path}/meshes/${parts_dir}
+            cp -r ${parts_path}/meshes/* ${aero_description_path}/meshes/${parts_dir}
+        fi
     fi
 
 done < $robot_file


### PR DESCRIPTION
current shop setup copies meshes from robot part directory.
however, when we want to create parts with different urdf settings (same meshes but with different settings such as velocity, ranges, or reduced joints) this is inconvenient for four reasons.

one, we are duplicating tons of .dae files, which is a waste of memory.
two, we have to change all the model paths in the urdf/.xacro.
three, we cannot distinguish whether there is actually a diff in .dae or if it is just a copy.
four, when there is a fix in the .dae, we have to recopy it for all directories that has duplicated the mesh.

this pull request allows you to add a *meshes.txt* under meshes if you are using the same meshes from an existing robot part directory.
by writing```aero_shop/typeF_upperbody``` in *meshes/meshes.txt*, the script will copy meshes from typeF_upperbody.

downsides. the script does not handle recursive reference. so if typeF_upperbody had a meshes.txt instead of .dae files, the setup will fail.