### PR TITLE
update grasp

### DIFF
--- a/aero_ros_controller/src/AeroGrasp.hh
+++ b/aero_ros_controller/src/AeroGrasp.hh
@@ -39,33 +39,36 @@ class AeroGrasp
    ROS_WARN("AeroGrasp: Grasp pos: %d, script %d, power: %d",
             _req.position, _req.script, _req.power);
 
-   ROS_WARN("AeroGrasp: setMaxSingleCurrent");
-   hw_->setMaxSingleCurrent(_req.position, _req.power);
-
-   usleep(200 * 1000); // 200ms sleep ???
-
-   ROS_WARN("AeroGrasp: handScript");
-   hw_->handScript(_req.position, _req.script);
-
    // return if cancel script
    if (_req.script == aero_startup::GraspControlRequest::SCRIPT_CANCEL) {
-     ROS_WARN("AeroGrasp: End Grasp");
+     ROS_WARN("AeroGrasp: setMaxSingleCurrent");
+     hw_->setMaxSingleCurrent(_req.position, _req.power);
+     ROS_WARN("AeroGrasp: handscript cancel");
+     hw_->handScript(_req.position, _req.script);
      // hw_->startUpper(); // not needed
      return true;
-   }
-
-   if(_req.script == aero_startup::GraspControlRequest::SCRIPT_GRASP) {
-     usleep(3000 * 1000); // wait 3 seconds, must be 3!
-   } else if(_req.script == aero_startup::GraspControlRequest::SCRIPT_UNGRASP) {
-     usleep(1000 * 1000);
+   } else if (_req.script == aero_startup::GraspControlRequest::SCRIPT_GRASP) {
+     ROS_WARN("AeroGrasp: setMaxSingleCurrent");
+     hw_->setMaxSingleCurrent(_req.position, _req.power);
+     ROS_WARN("AeroGrasp: handScript grasp");
+     hw_->handScript(_req.position, _req.script);
+     ros::Duration(2.8).sleep(); // wait 2.8 seconds, as script takes max 2.8 seconds!
+   } else if (_req.script == aero_startup::GraspControlRequest::SCRIPT_UNGRASP) {
+     ROS_WARN("AeroGrasp: handScript ungrasp");
+     hw_->handScript(_req.position, _req.script);
+     ros::Duration(2.7).sleep(); // wait 2.7 seconds, as script takes max 2.7 seconds!
+   } else if (_req.script == aero_startup::GraspControlRequest::COMMAND_SERVO) {
+     ROS_WARN("AeroGrasp: cancel step-out");
+     hw_->servo(_req.position);
+     ROS_WARN("AeroGrasp: setMaxSingleCurrent"); // just in case
+     hw_->setMaxSingleCurrent(_req.position, (100 << 8) + 30);
    }
 
    ROS_WARN("AeroGrasp: End Grasp");
-   _res.angles.resize(2);
-#if 0
-   _res.angles[0] = upper_angles[13];
-   _res.angles[1] = upper_angles[27];
-#endif
+   // !!!!!!!!!!!!!!! not supported
+   // _res.angles.resize(2);
+   // _res.angles[0] = upper_angles[13];
+   // _res.angles[1] = upper_angles[27];
    // hw_->startUpper(); // not needed
    return true;
  }

--- a/aero_ros_controller/src/AeroHandController.cc
+++ b/aero_ros_controller/src/AeroHandController.cc
@@ -123,12 +123,11 @@ public:
       grasp_time = req.time_sec;
     }
     res.success = true; // substitude 'false' if needed
+    res.status = "grasp check not supported, always return success";
 
     switch (req.command) {
     case HandControlRequest::COMMAND_GRASP:
       {
-        // because grasp is really really slow, first grasp-angle
-        GraspAngle(req.hand, 0.0, 0.0, grasp_time);
         if (req.hand == HandControlRequest::HAND_LEFT) {
           g_srv.request.position = POSITION_Left;
           g_srv.request.script = GraspControlRequest::SCRIPT_GRASP;
@@ -143,9 +142,9 @@ public:
         }
 
         if (power != 0) {
-          g_srv.request.power = (power << 8) + 30;
+          g_srv.request.power = (power << 8) + power;
         } else {
-          g_srv.request.power = (100 << 8) + 30;
+          g_srv.request.power = (100 << 8) + 100;
         }
         ROS_DEBUG("call pos: %d, script: %d, power %d",
                   g_srv.request.position, g_srv.request.script, g_srv.request.power);
@@ -153,169 +152,77 @@ public:
           g_client_.call(g_srv);
         }
 
-        {
-          robot_interface::joint_angle_map act_map;
-          hi->getActualPositions(act_map);
-          double pos0, pos1;
-          if (!!hi->lhand) {
-            if (!getPosition(act_map, l_grasp_check_joint, pos0)) return false;
-          }
-          if (!!hi->rhand) {
-            if (!getPosition(act_map, r_grasp_check_joint, pos1)) return false;
-          }
+	// !!!!!!!!!!!!!!!!!! Currently not supported
+        // {
+        //   robot_interface::joint_angle_map act_map;
+        //   hi->getActualPositions(act_map);
+        //   double pos0, pos1;
+        //   if (!!hi->lhand) {
+        //     if (!getPosition(act_map, l_grasp_check_joint, pos0)) return false;
+        //   }
+        //   if (!!hi->rhand) {
+        //     if (!getPosition(act_map, r_grasp_check_joint, pos1)) return false;
+        //   }
 
-          if(g_srv.response.angles.size() < 2) {
-            g_srv.response.angles.resize(2);
-          }
-          g_srv.response.angles[0] = pos0;
-          g_srv.response.angles[1] = pos1;
-        }
+        //   if(g_srv.response.angles.size() < 2) {
+        //     g_srv.response.angles.resize(2);
+        //   }
+        //   g_srv.response.angles[0] = pos0;
+        //   g_srv.response.angles[1] = pos1;
+        // }
 
-        std::string status_msg = "grasp success";
+        // std::string status_msg = "grasp success";
 
-        if (req.hand == HandControlRequest::HAND_LEFT) {
-          if (L_GRASP_CHECK_bad(g_srv, req)) {
-            ROS_DEBUG("bad %f, %f", g_srv.response.angles[0], req.thre_warn);
-            res.success = false;
-            status_msg = "grasp bad";
-          }
-          if (L_GRASP_CHECK_fail(g_srv, req)) {
-            ROS_DEBUG("failed %f, %f", g_srv.response.angles[0], req.thre_fail);
-            res.success = false;
-            status_msg = "grasp failed";
-          }
-        } else if (req.hand == HandControlRequest::HAND_RIGHT) {
-          if (R_GRASP_CHECK_bad(g_srv, req)) {
-            ROS_DEBUG("bad %f, %f", g_srv.response.angles[1], req.thre_warn);
-            res.success = false;
-            status_msg = "grasp bad";
-          }
-          if (R_GRASP_CHECK_fail(g_srv, req)) {
-            ROS_DEBUG("faied %f, %f", g_srv.response.angles[1], req.thre_fail);
-            res.success = false;
-            status_msg = "grasp failed";
-          }
-        } else {
-          ROS_ERROR("Unexpected hand %d", req.hand);
-          return false;
-        }
+        // if (req.hand == HandControlRequest::HAND_LEFT) {
+        //   if (L_GRASP_CHECK_bad(g_srv, req)) {
+        //     ROS_DEBUG("bad %f, %f", g_srv.response.angles[0], req.thre_warn);
+        //     res.success = false;
+        //     status_msg = "grasp bad";
+        //   }
+        //   if (L_GRASP_CHECK_fail(g_srv, req)) {
+        //     ROS_DEBUG("failed %f, %f", g_srv.response.angles[0], req.thre_fail);
+        //     res.success = false;
+        //     status_msg = "grasp failed";
+        //   }
+        // } else if (req.hand == HandControlRequest::HAND_RIGHT) {
+        //   if (R_GRASP_CHECK_bad(g_srv, req)) {
+        //     ROS_DEBUG("bad %f, %f", g_srv.response.angles[1], req.thre_warn);
+        //     res.success = false;
+        //     status_msg = "grasp bad";
+        //   }
+        //   if (R_GRASP_CHECK_fail(g_srv, req)) {
+        //     ROS_DEBUG("faied %f, %f", g_srv.response.angles[1], req.thre_fail);
+        //     res.success = false;
+        //     status_msg = "grasp failed";
+        //   }
+        // } else {
+        //   ROS_ERROR("Unexpected hand %d", req.hand);
+        //   return false;
+        // }
 
-        res.status = status_msg;
+        // res.status = status_msg;
       }
       break;
     case HandControlRequest::COMMAND_UNGRASP:
       {
-        OpenHand(req.hand, grasp_time);
+        OpenHand(req.hand); // applying time may cause step out, handle with script
         res.status = "ungrasp success";
       }
       break;
     case HandControlRequest::COMMAND_GRASP_ANGLE:
       {
+	// TODO: return fail if step-out was detected
         GraspAngle(req.hand, req.larm_angle, req.rarm_angle, grasp_time);
         res.status = "grasp-angle success";
       }
       break;
-    case HandControlRequest::COMMAND_GRASP_FAST:
-      {
-        // grasp till angle, check if grasp is okay, then hold
-        GraspAngle(req.hand, 0.0, 0.0, grasp_time); // grasp takes about 1 sec
-        ROS_WARN("end_grasp");
-        if (req.hand == HandControlRequest::HAND_LEFT) {
-          robot_interface::joint_angle_map act_map;
-          hi->getActualPositions(act_map);
-          double pos;
-          if(!getPosition(act_map, l_grasp_fast_check_joint, pos)) return false;
-
-          if (fabs(pos) < 0.05) {
-            ROS_DEBUG("fail fabs(pos) = %f < 0.05", pos);
-            if (fabs(req.larm_angle) < 0.05) {
-              ROS_DEBUG("fail: OpenHand");
-              OpenHand(req.hand, grasp_time);
-            } else {
-              ROS_DEBUG("fail: GraspAngle");
-              GraspAngle(req.hand, req.larm_angle, 0.0, grasp_time);
-            }
-            res.success = false;
-            res.status = "grasp failed";
-            return true;
-          }
-          g_srv.request.position = POSITION_Left;
-          g_srv.request.script = GraspControlRequest::SCRIPT_GRASP;
-          executing_flg_left_ = true; //executing_grasp_script
-        } else if (req.hand == HandControlRequest::HAND_RIGHT) {
-          robot_interface::joint_angle_map act_map;
-          hi->getActualPositions(act_map);
-          double pos;
-          if(!getPosition(act_map, r_grasp_fast_check_joint, pos)) return false;
-
-          if (fabs(pos) < 0.05) {
-            ROS_DEBUG("fail fabs(pos) = %f < 0.05", pos);
-            if (fabs(req.rarm_angle) < 0.05) {
-              ROS_DEBUG("fail: OpenHand");
-              OpenHand(req.hand, grasp_time);
-            } else {
-              ROS_DEBUG("fail: GraspAngle");
-              GraspAngle(req.hand, 0.0, req.rarm_angle, grasp_time);
-            }
-            res.success = false;
-            res.status = "grasp failed";
-            return true;
-          }
-          g_srv.request.position = POSITION_Right;
-          g_srv.request.script = GraspControlRequest::SCRIPT_GRASP;
-          executing_flg_right_ = true; //executing_grasp_script
-        }
-
-        if (power != 0) {
-          g_srv.request.power = (power << 8) + 30;
-        } else {
-          g_srv.request.power = (100 << 8) + 30;
-        }
-        ROS_DEBUG("call pos: %d, script: %d, power %d",
-                  g_srv.request.position, g_srv.request.script, g_srv.request.power);
-        if (exist_grasp_server_) {
-          g_client_.call(g_srv);
-        }
-
-        {
-          robot_interface::joint_angle_map act_map;
-          hi->getActualPositions(act_map);
-          double pos0, pos1;
-          if (!!hi->lhand) {
-            if (!getPosition(act_map, l_grasp_check_joint, pos0)) return false;
-          }
-          if (!!hi->rhand) {
-            if (!getPosition(act_map, r_grasp_check_joint, pos1)) return false;
-          }
-
-          if(g_srv.response.angles.size() < 2) {
-            g_srv.response.angles.resize(2);
-          }
-          g_srv.response.angles[0] = pos0;
-          g_srv.response.angles[1] = pos1;
-        }
-        std::string status_msg = "grasp success";
-        if (req.hand == HandControlRequest::HAND_LEFT) {
-          if (L_GRASP_FAST_CHECK(g_srv, req)) {
-            ROS_DEBUG("faied %f, %f", g_srv.response.angles[0], req.thre_fail);
-            res.success = false;
-            status_msg = "grasp failed";
-          }
-        } else if (req.hand == HandControlRequest::HAND_RIGHT) {
-          if (L_GRASP_FAST_CHECK(g_srv, req)) {
-            ROS_DEBUG("faied %f, %f", g_srv.response.angles[1], -req.thre_fail);
-            res.success = false;
-            status_msg = "grasp failed";
-          }
-        }
-        res.status = status_msg;
-      }
-      break;
+    default:
+      ROS_ERROR("command does not exist for aero_startup/HandControl service");
     }
     return true;
   }
 
-  void OpenHand(int hand, double _time=1.0)
+  void OpenHand(int hand)
   {
     ROS_DEBUG("OpenHand %d", hand);
     aero_startup::GraspControl g_srv;
@@ -325,30 +232,19 @@ public:
       g_srv.request.position = POSITION_Left;
       g_srv.request.script = GraspControlRequest::SCRIPT_UNGRASP;
       executing_flg_left_ = false;
-
-      L_OPEN();
+      // L_OPEN();
     } else if (hand == HandControlRequest::HAND_RIGHT) {
       g_srv.request.position = POSITION_Right;
       g_srv.request.script = GraspControlRequest::SCRIPT_UNGRASP;
       executing_flg_right_ = false;
-
-      R_OPEN();
+      // R_OPEN();
     }
-    //
-    ros::Time start = ros::Time::now() + ros::Duration(0.002);
-    ROS_DEBUG("OpenHand: sendAngles");
-    hi->sendAngles(map, _time, start);
-    //
-    g_srv.request.power = (100 << 8) + 30;
-    ROS_DEBUG("call pos: %d, script: %d, power %d",
-              g_srv.request.position, g_srv.request.script, g_srv.request.power);
+    // g_srv.request.power = (100 << 8) + 30; // no meaning
+    ROS_DEBUG("call pos: %d, script: %d",
+              g_srv.request.position, g_srv.request.script);
     if (exist_grasp_server_) {
       g_client_.call(g_srv);
     }
-
-    // not wait ....
-    //ROS_DEBUG("OpanHand: wait_interpolation");
-    //hi->wait_interpolation();
   }
 
   void GraspAngle (int hand, float larm_angle, float rarm_angle, float time=0.5)
@@ -400,6 +296,11 @@ public:
     ROS_DEBUG("GraspAngle: wait_interpolation");
     hi->wait_interpolation();
     usleep(50*1000); // sleep 50ms for waiting to finish position command
+    aero_startup::GraspControl g_srv;
+    g_srv.request.script = GraspControlRequest::COMMAND_SERVO; // in case step-out
+    if (exist_grasp_server_) {
+      g_client_.call(g_srv);
+    }
   }
 
 private:

--- a/aero_ros_controller/src/aero_robot_hardware.h
+++ b/aero_ros_controller/src/aero_robot_hardware.h
@@ -58,6 +58,7 @@
 
 // AERO
 #include "aero_hardware_interface/Constants.hh"
+#include "aero_hardware_interface/CommandList.hh"
 #include "aero_hardware_interface/AeroControllers.hh"
 
 #include "aero_hardware_interface/AngleJointNames.hh"
@@ -157,6 +158,11 @@ public:
   void startUpper() {
     mutex_upper_.lock();
     upper_send_enable_ = true;
+    mutex_upper_.unlock();
+  }
+  void servo(uint16_t _sendnum) { // send servo on command
+    mutex_upper_.lock();
+    controller_upper_->set_command(aero::controller::CMD_MOTOR_SRV, _sendnum, 1);
     mutex_upper_.unlock();
   }
   double getPeriod() { return ((double)CONTROL_PERIOD_US_) / (1000 * 1000); }

--- a/aero_shop/seed_hand/controller/AeroHandController.hh
+++ b/aero_shop/seed_hand/controller/AeroHandController.hh
@@ -18,21 +18,12 @@ const std::string r_grasp_fast_check_joint = "l_indexbase_joint";
 #define L_GRASP_FAST_CHECK(g_srv, req) (g_srv.response.angles[0] >   req.thre_fail)
 #define R_GRASP_FAST_CHECK(g_srv, req) (g_srv.response.angles[1] < - req.thre_fail)
 
-#define L_OPEN() {                                   \
-    map["l_thumb_joint"] = -15.0 * M_PI / 180.0;     \
-    map["l_indexbase_joint"] = 55.0 * M_PI / 180.0;  \
-  }
-#define R_OPEN() {                                    \
-    map["r_thumb_joint"] =  15.0 * M_PI / 180.0;      \
-    map["r_indexbase_joint"] =  -55.0 * M_PI / 180.0; \
-  }
-
 #define L_GRASP() {                                             \
-    map["l_indexbase_joint"]  = -larm_angle * M_PI / 180;       \
-    map["l_thumb_joint"]      =  larm_angle * M_PI / 180/ 4.0;  \
+    map["l_indexbase_joint"]  = -larm_angle;       \
+    map["l_thumb_joint"]      =  larm_angle/ 4.0;  \
   }
 #define R_GRASP() {                                             \
-    map["r_indexbase_joint"]  = -rarm_angle * M_PI / 180;       \
-    map["r_thumb_joint"]      =  rarm_angle * M_PI / 180 / 4.0; \
+    map["r_indexbase_joint"]  = -rarm_angle;       \
+    map["r_thumb_joint"]      =  rarm_angle/ 4.0; \
   }
 /// end dependant

--- a/aero_shop/trx_s/controller/AeroHandController.hh
+++ b/aero_shop/trx_s/controller/AeroHandController.hh
@@ -18,17 +18,10 @@ const std::string r_grasp_fast_check_joint = "r_thumb_joint";
 #define L_GRASP_FAST_CHECK(g_srv, req) (g_srv.response.angles[0] >   req.thre_fail)
 #define R_GRASP_FAST_CHECK(g_srv, req) (g_srv.response.angles[1] < - req.thre_fail)
 
-#define L_OPEN() {                                   \
-    map["l_thumb_joint"] = -15.0 * M_PI / 180.0;     \
-  }
-#define R_OPEN() {                                   \
-    map["r_thumb_joint"] =  15.0 * M_PI / 180.0;     \
-  }
-
 #define L_GRASP() {                                             \
-    map["l_thumb_joint"]      =  larm_angle * M_PI / 180.0;  \
+    map["l_thumb_joint"]      =  larm_angle;  \
   }
 #define R_GRASP() {                                             \
-    map["r_thumb_joint"]      =  rarm_angle * M_PI / 180.0; \
+    map["r_thumb_joint"]      =  rarm_angle; \
   }
 /// end dependant

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.cc
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.cc
@@ -544,6 +544,14 @@ void AeroControllerProto::set_motor_gain(
 }
 
 //////////////////////////////////////////////////
+void AeroControllerProto::set_command(
+    uint8_t _cmd, uint8_t _num, uint16_t _data)
+{
+  boost::mutex::scoped_lock lock(ctrl_mtx_);
+  seed_.send_command(_cmd, _num, _data);
+}
+
+//////////////////////////////////////////////////
 void AeroControllerProto::set_command(uint8_t _cmd,
                                       std::vector<int16_t>& _stroke_vector)
 {

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.hh
@@ -189,6 +189,12 @@ namespace aero
       /// @param _stroke_vector stroke vector
      public: void set_motor_gain(std::vector<int16_t>& _stroke_vector);
 
+      /// @brief send single command to SEED controller
+      /// @param _cmd Command ID
+      /// @param _num Send ID
+      /// @param _data data
+     public: void set_command(uint8_t _cmd, uint8_t _num, uint16_t _data);
+
       /// @brief abstract of set commands
       /// @param _cmd command id
       /// @param _stroke_vector stroke vector

--- a/aero_startup/srv/GraspControl.srv
+++ b/aero_startup/srv/GraspControl.srv
@@ -6,6 +6,7 @@ int16 script
 int16 SCRIPT_GRASP=2
 int16 SCRIPT_UNGRASP=3
 int16 SCRIPT_CANCEL=4
+int16 COMMAND_SERVO=33
 ## power???
 int16 power
 ---

--- a/aero_startup/srv/HandControl.srv
+++ b/aero_startup/srv/HandControl.srv
@@ -6,7 +6,6 @@ int32 HAND_BOTH=3
 ## sending command
 int32 command
 int32 COMMAND_GRASP=1
-int32 COMMAND_GRASP_FAST=2
 int32 COMMAND_GRASP_ANGLE=3
 int32 COMMAND_UNGRASP=4
 ## power

--- a/aero_std/include/aero_std/AeroMoveitInterface.hh
+++ b/aero_std/include/aero_std/AeroMoveitInterface.hh
@@ -336,15 +336,11 @@ namespace aero
       /// @brief send grasp command to real robot
       /// @param[in] _arm aero::arm::(rarm|larm)
       /// @param[in] _power grasp power from 0\% to 100\%
-    public: bool sendGrasp(aero::arm _arm, int _power=100, float _tm_sec = -1.0);
+    public: bool sendGrasp(aero::arm _arm, int _power=100);
       /// @brief send grasp command to real robot (automatically opens when fail detected)
-      /// @param[in] _arm aero::arm::(rarm|larm)
-      /// @param[in] _power grasp power from 0\% to 100\%
-      /// @param[in] _power fail angle in radian from 0.0 to 0.9
-    public: bool sendGraspFast(aero::arm _arm, int _power=100, float _thre_fail=0.0, float _tm_sec = -1.0);
       /// @brief open real robot's hand
       /// @param[in] _arm aero::arm::(rarm|larm)
-    public: bool openHand(aero::arm _arm, float _tm_sec = -1.0);
+    public: bool openHand(aero::arm _arm);
       /// @brief send desired hand angle to real robot
       /// @param[in] _arm aero::arm::(rarm|larm)
       /// @param[in] _rad desired angle in radian

--- a/aero_std/src/AeroMoveitInterface.cc
+++ b/aero_std/src/AeroMoveitInterface.cc
@@ -948,39 +948,23 @@ void aero::interface::AeroMoveitInterface::setHandsFromJointStates_()
 }
 
 //////////////////////////////////////////////////
-bool aero::interface::AeroMoveitInterface::sendGrasp(aero::arm _arm, int _power, float _tm_sec)
+bool aero::interface::AeroMoveitInterface::sendGrasp(aero::arm _arm, int _power)
 {
   aero_startup::HandControl srv;
   srv.request.command = aero_startup::HandControlRequest::COMMAND_GRASP;
   srv.request.power   = _power;
   srv.request.thre_warn = -0.9;
   srv.request.thre_fail = 0.2;
-  srv.request.time_sec = _tm_sec;
 
   return callHandSrv_(_arm, srv);
 }
 
 //////////////////////////////////////////////////
-bool aero::interface::AeroMoveitInterface::sendGraspFast(aero::arm _arm, int _power, float _thre_fail, float _tm_sec)
-{
-  aero_startup::HandControl srv;
-  srv.request.command = aero_startup::HandControlRequest::COMMAND_GRASP_FAST;
-  srv.request.power   = _power;
-  srv.request.thre_fail = _thre_fail;
-  srv.request.larm_angle = getHand(aero::arm::larm) * 180.0 / M_PI;
-  srv.request.rarm_angle = getHand(aero::arm::rarm) * 180.0 / M_PI;
-  srv.request.time_sec = _tm_sec;
-
-  return callHandSrv_(_arm, srv);
-}
-
-//////////////////////////////////////////////////
-bool aero::interface::AeroMoveitInterface::openHand(aero::arm _arm, float _tm_sec)
+bool aero::interface::AeroMoveitInterface::openHand(aero::arm _arm)
 {
   aero_startup::HandControl srv;
   srv.request.command = aero_startup::HandControlRequest::COMMAND_UNGRASP;
   srv.request.power   = 0;
-  srv.request.time_sec = _tm_sec;
 
   return callHandSrv_(_arm, srv);
 }
@@ -995,13 +979,17 @@ bool aero::interface::AeroMoveitInterface::sendHand(aero::arm _arm, double _rad,
     return false;
   }
 
+  if (_tm_sec < 0) {
+    ROS_WARN("sendHand with no specified time can lead to step-out, time value of 3[sec] recommended");
+  }
+
   aero_startup::HandControl srv;
   srv.request.command = aero_startup::HandControlRequest::COMMAND_GRASP_ANGLE;
   srv.request.power   = 0;
   srv.request.thre_warn = 0.0;
   srv.request.thre_fail = 0.0;
-  srv.request.larm_angle = _rad * 180.0 / M_PI;
-  srv.request.rarm_angle = _rad * 180.0 / M_PI;
+  srv.request.larm_angle = _rad;
+  srv.request.rarm_angle = _rad;
   srv.request.time_sec = _tm_sec;
 
   return callHandSrv_(_arm, srv);


### PR DESCRIPTION
tested on real robot (trx_s).

This update is highly recommended. This fixes some of the issues we have with the hand.
The current hand controller follows a very old firmware script. The updates are listed below:

- remove sending angles in grasp. reason: not required. current grasp finishes in 2.8 seconds.
- remove sending angles in ungrasp. reason: not required. moreover, this could cause step-out.
- remove time setups for grasp, ungrasp. reason: not used due to above changes.
- set electrical current down in grasp to power. reason: current down to 30 is not enough for grasping.
- remove setting electrical current in ungrasp. reason: not required.
- add servo_on at end of grasp_angle. reason: to cancel loud noises when there is a step-out.