### PR TITLE
improve communication load

### DIFF
--- a/aero_ros_controller/src/aero_robot_hardware.cpp
+++ b/aero_ros_controller/src/aero_robot_hardware.cpp
@@ -295,7 +295,7 @@ void AeroRobotHW::read(const ros::Time& time, const ros::Duration& period)
   }
   mutex_upper_.unlock();
   //
-  readPos(time, period, true);
+  //readPos(time, period, true);
 
   return;
 }
@@ -384,7 +384,7 @@ void AeroRobotHW::write(const ros::Time& time, const ros::Duration& period)
   mutex_lower_.unlock();
 
   // read
-  //readPos(time, period, false);
+  readPos(time, period, false);
 }
 
 void AeroRobotHW::writeWheel(const std::vector< std::string> &_names, const std::vector<int16_t> &_vel, double _tm_sec) {

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.cc
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.cc
@@ -449,6 +449,7 @@ void AeroControllerProto::get_data(std::vector<int16_t>& _stroke_vector)
   }
 
   if (cmd == CMD_MOVE_ABS_POS ||
+      cmd == CMD_MOVE_ABS_POS_RET ||
       cmd == CMD_GET_POS ||
       cmd == CMD_GET_CUR ||
       cmd == CMD_GET_TMP ||


### PR DESCRIPTION
In the current system, ``set_position`` command are always sent and present positions are returned.
So, it is not necessary to send ``get_actual_stroke_vector`` command.
You can get below benefits:
*  faster communication cycle 
* smoothly movement
* reduce noise (a bit) 