### PR TITLE
fix dummy wheels and scan

### DIFF
--- a/aero_startup/aero_move_base/launch/wheel_with_dummy.launch
+++ b/aero_startup/aero_move_base/launch/wheel_with_dummy.launch
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <launch>
   <!-- dummy scan -->
-  <node name="dummy_scan" pkg="aero_startup" type="dummy_scan.py" />
+  <arg name="scan_topic" default="map"/>
+  <node name="dummy_scan" pkg="aero_startup" type="dummy_scan.py">
+    <remap from="map" to="$(arg scan_topic)"/>
+  </node>
 
-  <!-- Run the map server -->
+  <!-- Run map navigation -->
   <arg name="map_file" default="$(find aero_startup)/aero_move_base/maps/blank.yaml"/>
-  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
-
-  <!--- Run AMCL -->
-  <include file="$(find aero_startup)/aero_move_base/launch/amcl.launch" />
-
-  <!--- Run Move Base -->
-  <include file="$(find aero_startup)/aero_move_base/launch/move_base.launch">
+  <arg name="costmap_file" default="$(find aero_startup)/aero_move_base/maps/blank.yaml"/>
+  <include file="$(find aero_startup)/aero_move_base/launch/static_map_navigation.launch">
     <arg name="map_file" value="$(arg map_file)" />
+    <arg name="costmap_file" value="$(arg costmap_file)"/>
   </include>
+
 </launch>


### PR DESCRIPTION
fix for #363 

Also, I've noticed that the tf lookup transform returns a very weird orientation with dummy scan. Calculating asin and acos of the quaternion returns two different values. In addition, sometimes it is returning a reverted quaternion.
Since I saw this happening with at least two machines, I've decided to change the dummy scan to calculate from positions rather than using the tf orientation.