### PR TITLE
Update LRF sensor range and amcl particle filter parameters

### DIFF
--- a/aero_startup/aero_move_base/launch/amcl.launch
+++ b/aero_startup/aero_move_base/launch/amcl.launch
@@ -55,8 +55,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <param name="laser_model_type" value="likelihood_field"/>
     <!-- <param name="laser_model_type" value="beam"/> -->
     <param name="laser_likelihood_max_dist" value="2.0"/>
-    <param name="update_min_d" value="0.25"/>
-    <param name="update_min_a" value="0.2"/>
+    <param name="update_min_d" value="0.01"/>
+    <param name="update_min_a" value="0.01"/>
     <param name="odom_frame_id" value="odom"/>
     <param name="resample_interval" value="1"/>
     <!-- Increase tolerance because the computer can get quite busy -->

--- a/aero_startup/aero_move_base/launch/wheel_bringup.launch
+++ b/aero_startup/aero_move_base/launch/wheel_bringup.launch
@@ -10,9 +10,9 @@
     <param name="~ip_address" value="$(arg ~ip_address)" />
     <param name="~frame_id" value="$(arg ~frame_id)" />
 
-    <!-- +-135[deg] -->     
-    <param name="~angle_min" value="-2.35619449" />
-    <param name="~angle_max" value="2.35619449" /> 
+    <!-- +-115[deg] -->
+    <param name="~angle_min" value="-2.007128639793479" />
+    <param name="~angle_max" value="2.007128639793479" />
 
   </node>
 


### PR DESCRIPTION
Changed two parameters LRF sensor range and amcl particle filter update value to improve  move performance.

1. Change LRF sensor range.
LRF sensor hits this bar attached on move base(second fig). As a result sensor value appear on map like below picture as noises. 
Robot often stuck obstacle because local cost map is calculated include this noise.
In the standard, LRF sensor range is set 135 degree. I change this value 135 to 115 degree.
Finally, robot ignore this noise (third picture)

![screenshot from 2018-09-25 00-00-16](https://user-images.githubusercontent.com/22497720/45993364-996fca80-c0c9-11e8-93a0-7baff13c72ef.png)
![lrf_and_bar_interference](https://user-images.githubusercontent.com/22497720/45993371-a096d880-c0c9-11e8-8277-016d7d3f033d.JPG)
![screenshot from 2018-09-25 00-00-40](https://user-images.githubusercontent.com/22497720/45993367-9bd22480-c0c9-11e8-9639-a4d71ad931e0.png)

2. Change amcl update value.
In the standard, amcl update value set 0.20 this mean localize position per 0.20 meter. 
For instance, in case of, moving path include corner, robot hit obstacle while moving.
After change this value 0.01 meter, robot localize own position every 0.01 meter.
As a result, robot can move corner without hitting.

This change inspired by this commit.
https://github.com/jsk-ros-pkg/jsk_robot/commit/e14a3b65a2b8aa737e6bd94af60fcb4556643152