### PR TITLE
[README] add comment about ros distro at bashrc explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ source ~/ros/${ROS_DISTRO}/devel/setup.bash
 
 ### source setup.bash in ~/.bashrc
 
-Please add the following line to ~/.bashrc
+Please add the following line to ~/.bashrc  
+Please change the part of 'indigo' according to the result of `echo ${ROS_DISTRO}` (ex. `kinetic`)
 ```
 source ~/ros/indigo/devel/setup.bash
 ```


### PR DESCRIPTION
I added trivial explanation about `source setup.bash` for ROS beginners.
What I mean is `source ~/ros/kinetic/devel/setup.bash` is required if we follow the instructions above and if we use ROS kinetic.

I'm one of participants of WMD2018 in Kashiwa-no-ha.