### PR TITLE
change default local planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Similarly, plug and unplug USB in lower body (command confirmed)
 ```
 roslaunch aero_startup aero_bringup.launch
 ```
+If you want to move wheels, please refer [aero_move_base](https://github.com/seed-solutions/aero-ros-pkg/blob/master/aero_startup/aero_move_base/README.md).
 
 ### View Robot Model
 

--- a/aero_startup/aero_move_base/README.md
+++ b/aero_startup/aero_move_base/README.md
@@ -15,10 +15,10 @@ Following files are sources of this Node;
 - AeroBaseController.cc (Auto Generated)
 - AeroMoveBase.{cc,hh}
 
-## Joystick Teleoperation
+## Move on Rviz without real robot
 
 ```
-roslaunch wheel_bringup.launch
+roslaunch aero_startup wheel_with_dummy.launch
 ```
 
 
@@ -27,36 +27,27 @@ roslaunch wheel_bringup.launch
 ### Mapping
 
 ```
-roslaunch wheel_with_making_map.launch
+roslaunch aero_startup wheel_with_making_map.launch
 ```
-
-will launch `wheel_bringup` and mapping nodes.
-
-For running mapping nodes on external PCs,
-launch `wheel_bringup.launch` on the Robot control PC first,
-then
-
-```
-roslaunch making_map_navigation.launch
-```
+After making map, you should run ```roslaunch aero_startup map_saver.launch``` to save map.
 
 
 ### Navigation
 
 ```
-roslaunch wheel_with_static_map.launch
+roslaunch aero_startup wheel_with_static_map.launch
 ```
 
-will launch `wheel_bringup` and navigation nodes.
+### Local Planner Setting
+You can choose base local planner from `TrajectoryPlannerROS`, `DWAPlannerROS`, `EBandPlannerROS`, `TebLocalPlannerROS`. (`TrajectoryPlannerROS` and `DWAPlannerROS` are not supported, now.)
+Default planner is `TebLocalPlannerROS`, described in move_base.launch.
 
-For running mapping nodes on external PCs,
-launch `wheel_bringup.launch` on the Robot control PC first,
-then
+Features are as follows:
+* [teb_local_planner/TebLocalPlannerROS](http://wiki.ros.org/teb_local_planner)  
+to avoid collision with people and when moving long distances, default settings do not allow moving sideways (this avoids the robot from moving diagonally in a straight path)
 
-```
-roslaunch static_map_navigation.launch
-```
-
+* [eband_local_planner/EEBandPlannerROS](http://wiki.ros.org/eband_local_planner)  
+to move sideways, if your robot is moving in a small area or is using the base to make small adjustments during manipulation
 
 ### For more information,
 

--- a/aero_startup/aero_move_base/config/TebLocalPlanner.yaml
+++ b/aero_startup/aero_move_base/config/TebLocalPlanner.yaml
@@ -1,0 +1,89 @@
+controller_frequency: 10.0
+
+TebLocalPlannerROS:
+
+  odom_topic: odom
+  map_frame: /map
+
+ # Trajectory
+  teb_autosize: True
+  dt_ref: 0.3
+  dt_hysteresis: 0.1
+  global_plan_overwrite_orientation: True
+  max_global_plan_lookahead_dist: 3.0
+  feasibility_check_no_poses: 5
+  allow_init_with_backwards_motion: False
+
+ # Robot
+  max_vel_x: 0.5
+  max_vel_y: 0.5
+  max_vel_x_backwards: 0.2
+  max_vel_theta: 0.5
+  acc_lim_x: 0.6
+  acc_lim_y: 0.6
+  acc_lim_theta: 0.6
+  min_turning_radius: 0.0
+  footprint_model: # types: "point", "circular", "two_circles", "line", "polygon"
+    type: "line"
+    line_start: [-0.1, 0.0] # for type "line"
+    line_end: [0.1, 0.0] # for type "line"
+
+# GoalTolerance
+  xy_goal_tolerance: 0.03
+  yaw_goal_tolerance: 0.05
+  free_goal_vel: False
+
+# Obstacles
+  min_obstacle_dist: 0.3
+  include_costmap_obstacles: True
+  costmap_obstacles_behind_robot_dist: 0.5
+  obstacle_poses_affected: 10
+  costmap_converter_plugin: "costmap_converter::CostmapToLinesDBSRANSAC"
+  costmap_converter_spin_thread: True
+  costmap_converter_rate: 5
+
+# Optimization
+  no_inner_iterations: 5
+  no_outer_iterations: 4
+  optimization_activate: True
+  optimization_verbose: False
+  penalty_epsilon: 0.1
+  weight_max_vel_x: 2
+  weight_max_vel_y: 2
+  weight_max_vel_theta: 1
+  weight_acc_lim_x: 1
+  weight_acc_lim_y: 0
+  weight_acc_lim_theta: 1
+  weight_kinematics_nh: 100
+  weight_kinematics_forward_drive: 1
+  weight_kinematics_turning_radius: 0.1
+  weight_optimaltime: 1
+  weight_obstacle: 50
+  #weight_dynamic_obstacle: 10 # not in use yet
+  #selection_alternative_time_cost: False # not in use yet
+
+# Homotopy Class Planner
+  enable_homotopy_class_planning: False
+  enable_multithreading: True
+  simple_exploration: False
+  max_number_classes: 2
+  roadmap_graph_no_samples: 15
+  roadmap_graph_area_width: 5
+  h_signature_prescaler: 0.5
+  h_signature_threshold: 0.1
+  obstacle_keypoint_offset: 0.1
+  obstacle_heading_threshold: 0.45
+  visualize_hc_graph: False
+
+## Configure plugins (namespace move_base/TebLocalPlannerROS/PLUGINNAME)
+## The parameters must be added for each plugin separately
+#costmap_converter/CostmapToLinesDBSRANSAC:
+  cluster_max_distance: 0.4
+  cluster_min_pts: 2
+  ransac_inlier_distance: 0.15
+  ransac_min_inliers: 10
+  ransac_no_iterations: 2000
+  ransac_remainig_outliers: 3
+  ransac_convert_outlier_pts: True
+  ransac_filter_remaining_outlier_pts: False
+  convex_hull_min_pt_separation: 0.1

--- a/aero_startup/aero_move_base/launch/amcl.launch
+++ b/aero_startup/aero_move_base/launch/amcl.launch
@@ -35,7 +35,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <param name="odom_model_type" value="omni-corrected"/>
     <param name="gui_publish_rate" value="10.0"/>
     <param name="laser_max_beams" value="60"/>
-    <param name="laser_max_range" value="12.0"/>
+    <param name="laser_max_range" value="10.0"/>
     <param name="min_particles" value="500"/>
     <param name="max_particles" value="2000"/>
     <param name="kld_err" value="0.05"/>

--- a/aero_startup/aero_move_base/launch/move_base.launch
+++ b/aero_startup/aero_move_base/launch/move_base.launch
@@ -30,7 +30,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 
   <arg name="base_global_planner" default="navfn/NavfnROS"/>
   <arg name="base_local_planner"
-       default="eband_local_planner/EBandPlannerROS"/>
+       default="teb_local_planner/TebLocalPlannerROS"/>
+    
+  <!-- <arg name="base_local_planner" -->
+  <!--      default="eband_local_planner/EBandPlannerROS"/> -->
 
   <!-- <arg name="base_local_planner"
        default="dwa_local_planner/DWAPlannerROS"/> -->
@@ -77,13 +80,18 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 	  -->
 
     <!-- For recovery Mode -->
-	  <param name="/TrajectoryPlannerROS/max_rotational_vel" value="0.5"/>
+    <param name="/TrajectoryPlannerROS/max_rotational_vel" value="0.5"/>
 
     <!-- Moving Parameters -->
-    <!-- EBandPlanner -->
+    <!-- TebLocalPlanner -->
     <rosparam
-        file="$(find aero_startup)/aero_move_base/config/EBandPlanner.yaml"
+        file="$(find aero_startup)/aero_move_base/config/TebLocalPlanner.yaml"
         command="load" />
+	  
+    <!-- EBandPlanner -->
+    <!-- <rosparam -->
+    <!--     file="$(find aero_startup)/aero_move_base/config/EBandPlanner.yaml" -->
+    <!--     command="load" /> -->
 
     <!-- DWAPlanner -->
     <!-- <rosparam -->

--- a/aero_startup/package.xml
+++ b/aero_startup/package.xml
@@ -40,6 +40,8 @@
   <run_depend>move_base</run_depend>
   <run_depend>map_server</run_depend>
   <run_depend>eband_local_planner</run_depend>
+  <run_depend>teb_local_planner</run_depend>
+  <run_depend>urg_node</run_depend>
 
   <export/>
 </package>


### PR DESCRIPTION
Present local planner can't avoid new obstacle not registered in the map(ex. person) .Teb Local Planner  works well. Can you try this ? @taichiH @sasabot 

In this settings, robot run as non-holonomic. You can change the parameter with reference to 
[Tutorial](http://wiki.ros.org/teb_local_planner/Tutorials/Planning%20for%20holonomic%20robots). However, I don't like this movement, especially when going straight.

This PR has some conflicts with https://github.com/seed-solutions/aero-ros-pkg/pull/382 , but it's written based on master branch because of [WIP]. sorry.
