### PR TITLE
add cmd vel mux

### DIFF
--- a/aero_startup/aero_move_base/launch/move_base.launch
+++ b/aero_startup/aero_move_base/launch/move_base.launch
@@ -42,6 +42,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 
   <node pkg="move_base" type="move_base" name="move_base"
         respawn="false" output="screen">
+    <remap from="cmd_vel" to="/move_base/cmd_vel"/>
     <!-- planner type -->
     <param name="base_global_planner" value="$(arg base_global_planner)"/>
     <param name="base_local_planner" value="$(arg base_local_planner)"/>

--- a/aero_teleop/config/cmd_vel_conf.yaml
+++ b/aero_teleop/config/cmd_vel_conf.yaml
@@ -1,0 +1,12 @@
+subscribers:
+  - name:        "Joy Teleop"
+    topic:       "/teleop/cmd_vel"
+    timeout:     0.1
+    priority:    1
+    short_desc:  "The teleop cmd_vel"
+  - name:        "Navigation stack"
+    topic:       "/move_base/cmd_vel"
+    timeout:     0.1
+    priority:    0
+    short_desc:  "Navigation stack controller"
+publisher:       "/cmd_vel"

--- a/aero_teleop/launch/aero_teleop.launch
+++ b/aero_teleop/launch/aero_teleop.launch
@@ -11,6 +11,7 @@
   </node>
 
   <node pkg="aero_teleop" name="teleop_joy" type="ps_teleop_node" output="screen">
+    <remap from="cmd_vel" to="/teleop/cmd_vel"/>
     <rosparam command="load" file="$(arg config_filepath)" />
   </node>
 </launch>

--- a/aero_teleop/launch/aero_teleop2.launch
+++ b/aero_teleop/launch/aero_teleop2.launch
@@ -11,6 +11,7 @@
   </node>
 
   <node pkg="aero_teleop" name="teleop_joy" type="xbox_one_teleop_node" output="screen">
+    <remap from="cmd_vel" to="/teleop/cmd_vel"/>
     <rosparam command="load" file="$(arg config_filepath)" />
   </node>
 </launch>

--- a/aero_teleop/launch/cmd_vel_mux.launch
+++ b/aero_teleop/launch/cmd_vel_mux.launch
@@ -1,0 +1,13 @@
+<launch>
+  <arg name="nodelet_manager_name"  default="nodelet_manager"/>
+  <arg name="config_file"           default="$(find aero_teleop2)/config/cmd_vel_conf.yaml"/>
+
+  <!-- nodelet manager -->
+  <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager"/>
+
+  <!-- velocity mulitplexer -->
+  <include file="$(find yocs_cmd_vel_mux)/launch/cmd_vel_mux.launch">
+    <arg name="nodelet_manager_name"  value="$(arg nodelet_manager_name)"/>
+    <arg name="config_file"           value="$(arg config_file)"/>
+  </include>
+</launch>

--- a/aero_teleop/package.xml
+++ b/aero_teleop/package.xml
@@ -11,6 +11,8 @@
   <build_depend>roscpp</build_depend>
   <build_depend>aero_std</build_depend>
 
+  <run_depend>yocs_cmd_vel_mux</run_depend>
+
   <export>
   </export>
 </package>


### PR DESCRIPTION
Adding cmd_vel_mux to enhance joystick teleop.
yocs_cmd_vel_mux (http://wiki.ros.org/yocs_cmd_vel_mux) can switch multiple cmd_vel topics.
Due to cmd_vel_mux, we can teleopelate robot during robot middle of moving by navigation stack node.

```
input:
/move_base/cmd_vel
/teleop/cmd_vel

output:
/cmd_vel
```