### PR TITLE
add function of getting voltage

### DIFF
--- a/aero_ros_controller/src/aero_robot_hardware.cpp
+++ b/aero_ros_controller/src/aero_robot_hardware.cpp
@@ -39,6 +39,7 @@
 
 #include "aero_robot_hardware.h"
 #include <urdf/model.h>
+#include "std_msgs/Float32.h"
 
 #include <thread>
 
@@ -192,6 +193,8 @@ bool AeroRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)//
 
   upper_send_enable_ = true;
   // lower_send_enable_ = true;
+
+  voltage_pub_ = robot_hw_nh.advertise<std_msgs::Float32>("voltage", 1);
 
   return true;
 }
@@ -426,6 +429,16 @@ void AeroRobotHW::stopWheelServo() {
 
   mutex_lower_.lock();
   controller_lower_->wheel_only_off();
+  mutex_lower_.unlock();
+}
+
+void AeroRobotHW::readVoltage(const ros::TimerEvent& _event) {
+  ROS_DEBUG("read voltage");
+
+  mutex_lower_.lock();
+  std_msgs::Float32 voltage;
+  voltage.data = controller_lower_->get_voltage();
+  voltage_pub_.publish(voltage);
   mutex_lower_.unlock();
 }
 

--- a/aero_ros_controller/src/aero_robot_hardware.h
+++ b/aero_ros_controller/src/aero_robot_hardware.h
@@ -139,6 +139,7 @@ public:
   void writeWheel(const std::vector< std::string> &_names, const std::vector<int16_t> &_vel, double _tm_sec);
   void startWheelServo();
   void stopWheelServo();
+  void readVoltage(const ros::TimerEvent& _event);
 
   std::string getVersion() {
     mutex_upper_.lock();
@@ -219,6 +220,8 @@ protected:
   int   CONTROL_PERIOD_US_;
   float OVERLAP_SCALE_;
   int   BASE_COMMAND_PERIOD_MS_;
+
+  ros::Publisher voltage_pub_;
 
   std::mutex mutex_lower_;
   std::mutex mutex_upper_;

--- a/aero_ros_controller/src/aero_ros_controller.cpp
+++ b/aero_ros_controller/src/aero_ros_controller.cpp
@@ -76,6 +76,8 @@ int main(int argc, char** argv)
 
   hw.getVersion();
 
+  ros::Timer timer = robot_nh.createTimer(ros::Duration(10), &AeroRobotHW::readVoltage,&hw);
+
   double period = hw.getPeriod();
   controller_manager::ControllerManager cm(&hw, nh);
 

--- a/aero_startup/aero_hardware_interface/AeroControllerProto.hh
+++ b/aero_startup/aero_hardware_interface/AeroControllerProto.hh
@@ -39,6 +39,9 @@ namespace aero
       /// @brief get version of SEED controller
      public: std::string get_version();
 
+      /// @brief get voltage of SEED controller
+     public: float get_voltage();
+
       /// @brief read from SEED controller
      public: void read(std::vector<uint8_t>& _read_data, const size_t _length=RAW_DATA_LENGTH);
 
@@ -104,6 +107,9 @@ namespace aero
 
       /// @brief get version of SEED controller
      public: std::string get_version();
+
+      /// @brief get voltage of SEED controller
+     public: float get_voltage();
 
       /// @brief servo on command
      public: void servo_on();

--- a/aero_startup/aero_hardware_interface/CommandList.hh
+++ b/aero_startup/aero_hardware_interface/CommandList.hh
@@ -29,7 +29,7 @@ namespace aero
 
     const static uint8_t CMD_GET_POS = 0x41;
     const static uint8_t CMD_GET_CUR = 0x42;
-    const static uint8_t CMD_GET_TMP = 0x43;
+    const static uint8_t CMD_GET_TMP_VOLT = 0x43;
     const static uint8_t CMD_GET_AD  = 0x44;
     const static uint8_t CMD_GET_DIO = 0x45;
 


### PR DESCRIPTION
This branch is test to get voltage.

* voltage topic```/aero_ros_controller/voltage``` is published every 10 seconds    
* to display at Rviz, please use [jsk_rviz_plugins/PieChart ](https://jsk-visualization.readthedocs.io/en/latest/jsk_rviz_plugins/plugins/pie_chart.html)    
max is 26[V], min is 22.2[V]
* this function is effective after```Version of driver is [2.0.32.0.0]```.  if you use older version, voltage is always 0
